### PR TITLE
Try hooking up printf

### DIFF
--- a/Demo/Src/main.c
+++ b/Demo/Src/main.c
@@ -92,7 +92,7 @@ int main(void)
   HAL_Init();
 
   /* USER CODE BEGIN Init */
-  ServerLog("hello world");
+  printf("hello world\n");
   CloseLogChannel();
   /* USER CODE END Init */
 
@@ -226,13 +226,11 @@ void StartDebugTask(void *argument)
 {
   /* USER CODE BEGIN 5 */
   unsigned n = 0;
-  char buffer[16];
 
   /* Infinite loop */
   for(;;)
   {
-    snprintf(buffer, sizeof(buffer), "ping %u", n);
-    ServerLog(buffer); // ServerLog() implicitly opens a connection if needed, we'll skip closing it given the repeating nature of this sample
+    printf("ping %u\n", n);
     n++;
     osDelay(1000);
   }


### PR DESCRIPTION
Not sure if we want this, but it certainly makes the logging.c file have a more familiar interface. Though it does make logging a bit more opaque, if a customer reads this and asks 'how does this work' they'll have to understand stdio, posix syscalls, etc etc.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
