### PR TITLE
Build each night

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,9 @@
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 18 * * *'
 
 jobs:
   build:


### PR DESCRIPTION
Github build artifacts expire after 3 months, and it was 3 months since we
did anything to main, so the current build no longer has its artifacts.

This fixes the downstream test fetching job.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
