### PR TITLE
Affix protobuf version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get -yqq update \
 RUN apt-get -yqq update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -o APT::Immediate-Configure=0 -yqq \
     python3 python3-pip protobuf-compiler
-RUN pip3 install cryptography protobuf
+RUN pip3 install cryptography protobuf~=3.0
 WORKDIR /home
 
 USER $USERNAME


### PR DESCRIPTION
protobuf==4 has breaking _pb2 API changes with files generated with protobuf==3. The tools repo has such a file checked in, so it can only be used with protobuf==3. 

This PR should fix the build.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
