### PR TITLE
Arrange for the logging channel to be closed when disconnected from

### DIFF
--- a/Demo/Inc/logging.h
+++ b/Demo/Inc/logging.h
@@ -5,8 +5,13 @@
 extern "C" {
 #endif
 
+void OpenNetworkNotifications(void);
+void CloseNetworkHandles(void);
 void ServerLog(const char *str);
 void CloseLogChannel(void);
+int NotificationIRQRaised(void);
+void ClearNotificationIRQ(void);
+void HandleIRQ(void);
 
 #ifdef __cplusplus
 }

--- a/Demo/Src/logging.c
+++ b/Demo/Src/logging.c
@@ -25,18 +25,112 @@ struct {
 
 // Central store for notification records. Holds one record at
 // a time -- each record is 16 bytes in size.
-static volatile struct MvNotification log_notification_buffer[16];
+#define NOTIFICATION_BUFFER_SIZE 16
+static volatile struct MvNotification log_notification_buffer[NOTIFICATION_BUFFER_SIZE];
 
 // Arbitrary user-specified uint32_t tags for any notifications
 // from Microvisor calls that support notifications:
 const uint32_t USER_TAG_LOGGING_REQUEST_NETWORK = 1;
 const uint32_t USER_TAG_LOGGING_OPEN_CHANNEL    = 2;
 
+static uint32_t buffer_pos;
+static int readOne(uint32_t type, struct MvNotification *n)
+{
+    volatile struct MvNotification *notification = &log_notification_buffer[buffer_pos];
+    if (notification->microseconds != 0 &&
+        notification->event_type == type) {
+            n->microseconds = notification->microseconds;
+            n->event_type = notification->event_type;
+            n->tag = notification->tag;
+            notification->event_type = 0;
+            buffer_pos += 1;
+            if (buffer_pos >= NOTIFICATION_BUFFER_SIZE) {
+                buffer_pos = 0;
+            }
+            return 1;
+    }
+    return 0;
+}
+
+static struct MvNotificationSetup notification_center_setup;
+struct MvRequestNetworkParams network_params;
+// Set up the channel's send and receive buffers
+static volatile uint8_t receive_buffer[16];
+static volatile uint8_t send_buffer[512] __attribute__((aligned(512)));
+uint8_t endpoint[] = { 'l', 'o', 'g' };
+static struct MvOpenChannelParams channel_params;
+volatile int irqHappened = 0;
+
+void OpenLogChannel(void)
+{
+    enum MvNetworkStatus netstat;
+    assert(MV_STATUS_OKAY == mvGetNetworkStatus(log_handles.network, &netstat));
+    if (netstat == MV_NETWORKSTATUS_CONNECTED) {
+        // Configure the required data channel
+        channel_params.version = 1,
+        channel_params.v1.notification_handle = log_handles.notification;
+        channel_params.v1.notification_tag    = USER_TAG_LOGGING_OPEN_CHANNEL;
+        channel_params.v1.network_handle      = log_handles.network;
+        channel_params.v1.receive_buffer      = (uint8_t*)receive_buffer;
+        channel_params.v1.receive_buffer_len  = sizeof(receive_buffer);
+        channel_params.v1.send_buffer         = (uint8_t*)send_buffer;
+        channel_params.v1.send_buffer_len     = sizeof(send_buffer);
+        channel_params.v1.channel_type        = MV_CHANNELTYPE_OPAQUEBYTES;
+        channel_params.v1.endpoint            = (uint8_t*)endpoint;
+        channel_params.v1.endpoint_len        = sizeof(endpoint);
+        uint32_t status = mvOpenChannel(&channel_params, &log_handles.channel);
+        assert(status == MV_STATUS_OKAY);
+    }
+}
+
+void CloseLogChannel(void)
+{
+    if (log_handles.channel != 0) {
+        uint32_t status = mvCloseChannel(&log_handles.channel);
+        assert(status == MV_STATUS_OKAY);
+    }
+    assert(log_handles.channel == 0);
+}
 
 void TIM8_BRK_IRQHandler(void) {
     // You can handle events here
+    irqHappened = 1;
 }
 
+static void TIM8_BRK_DSR(struct MvOpenChannelParams *channel_params)
+{
+    struct MvNotification notification;
+    while (readOne(MV_EVENTTYPE_NETWORKSTATUSCHANGED, &notification)) {
+        enum MvNetworkStatus netstat;
+        if (notification.tag == USER_TAG_LOGGING_REQUEST_NETWORK) {
+            assert(MV_STATUS_OKAY == mvGetNetworkStatus(log_handles.network, &netstat));
+        }
+        switch (netstat) {
+            case MV_NETWORKSTATUS_CONNECTED:
+                break;
+            default:
+            case MV_NETWORKSTATUS_CONNECTING:
+            case MV_NETWORKSTATUS_DELIBERATELYOFFLINE:
+                CloseLogChannel();
+                break;
+        }
+    }
+}
+
+int NotificationIRQRaised(void)
+{
+    return irqHappened;
+}
+
+void ClearNotificationIRQ(void)
+{
+    irqHappened = 0;
+}
+
+void HandleIRQ(void)
+{
+    TIM8_BRK_DSR(&channel_params);
+}
 
 /**
     @brief  Open a logging channel.
@@ -44,16 +138,15 @@ void TIM8_BRK_IRQHandler(void) {
     Open a data channel for Microvisor logging.
     This call will also request a network connection.
  */
-void OpenLogChannel(void) {
+void OpenNetworkNotifications(void) {
     // Clear the notification store
     memset((void *)log_notification_buffer, 0xFF, sizeof(log_notification_buffer));
+    buffer_pos = 0;
 
     // Configure a notification center for network-centric notifications
-    static struct MvNotificationSetup notification_center_setup = {
-        .irq = TIM8_BRK_IRQn,
-        .buffer = (struct MvNotification *)log_notification_buffer,
-        .buffer_size = sizeof(log_notification_buffer)
-    };
+    notification_center_setup.irq = TIM8_BRK_IRQn;
+    notification_center_setup.buffer = (struct MvNotification *)log_notification_buffer;
+    notification_center_setup.buffer_size = sizeof(log_notification_buffer);
 
     // Ask Microvisor to establish the notification center
     // and confirm that it has accepted the request
@@ -64,64 +157,13 @@ void OpenLogChannel(void) {
     NVIC_EnableIRQ(TIM8_BRK_IRQn);
 
     // Configure the network connection request
-    struct MvRequestNetworkParams network_params = {
-        .version = 1,
-        .v1 = {
-            .notification_handle = log_handles.notification,
-            .notification_tag = USER_TAG_LOGGING_REQUEST_NETWORK,
-        }
-    };
+    network_params.version = 1;
+    network_params.v1.notification_handle = log_handles.notification;
+    network_params.v1.notification_tag = USER_TAG_LOGGING_REQUEST_NETWORK;
 
     // Ask Microvisor to establish the network connection
     // and confirm that it has accepted the request
     status = mvRequestNetwork(&network_params, &log_handles.network);
-    assert(status == MV_STATUS_OKAY);
-
-    // Set up the channel's send and receive buffers
-    static volatile uint8_t receive_buffer[16];
-    static volatile uint8_t send_buffer[512] __attribute__((aligned(512)));
-    char endpoint[] = "log";
-
-    // Configure the required data channel
-    struct MvOpenChannelParams channel_params = {
-        .version = 1,
-        .v1 = {
-            .notification_handle = log_handles.notification,
-            .notification_tag    = USER_TAG_LOGGING_OPEN_CHANNEL,
-            .network_handle      = log_handles.network,
-            .receive_buffer      = (uint8_t*)receive_buffer,
-            .receive_buffer_len  = sizeof(receive_buffer),
-            .send_buffer         = (uint8_t*)send_buffer,
-            .send_buffer_len     = sizeof(send_buffer),
-            .channel_type        = MV_CHANNELTYPE_OPAQUEBYTES,
-            .endpoint            = (uint8_t*)endpoint,
-            .endpoint_len        = strlen(endpoint)
-        }
-    };
-
-    // The network connection is established by Microvisor asynchronously,
-    // so we wait for it to come up before opening the data channel -- which
-    // would fail otherwise
-    while (1) {
-        enum MvNetworkStatus status;
-
-        // Request the status of the network connection, identified by its handle.
-        // If we're good to continue, break out of the loop...
-        if (mvGetNetworkStatus(log_handles.network, &status) == MV_STATUS_OKAY &&
-            status == MV_NETWORKSTATUS_CONNECTED) {
-            break;
-        }
-
-        // ... or wait a short period before retrying
-        for (volatile unsigned i = 0; i < 50000; i++) {
-            // No op
-            __asm("nop");
-        }
-    }
-
-    // Ask Microvisor to open the channel
-    // and confirm that it has accepted the request
-    status = mvOpenChannel(&channel_params, &log_handles.channel);
     assert(status == MV_STATUS_OKAY);
 }
 
@@ -132,19 +174,8 @@ void OpenLogChannel(void) {
     Close the data channel -- and the network connection -- when
     we're done with it.
  */
-void CloseLogChannel(void) {
+void CloseNetworkHandles(void) {
     uint32_t status;
-
-    // If we have a valid channel handle -- ie. it is non-zero --
-    // then ask Microvisor to close it and confirm acceptance of
-    // the closure request.
-    if (log_handles.channel != 0) {
-        status = mvCloseChannel(&log_handles.channel);
-        assert(status == MV_STATUS_OKAY);
-    }
-
-    // Confirm the channel handle has been invalidated by Microvisor
-    assert(log_handles.channel == 0);
 
     // If we have a valid network handle, then ask Microvisor to
     // close the connection and confirm acceptance of the request.
@@ -184,6 +215,7 @@ void ServerLog(const char *message) {
     // will be invalid, ie. zero. If that's the case, open a channel
     if (log_handles.channel == 0) {
         OpenLogChannel();
+        while (log_handles.channel == 0) {}
     }
 
     // Write out the message string and then send a convenient
@@ -191,9 +223,9 @@ void ServerLog(const char *message) {
     // accepted the request to write data to the channel.
     uint32_t available, status;
     status = mvWriteChannel(log_handles.channel, (const uint8_t*)message, strlen(message), &available);
-    assert(status == MV_STATUS_OKAY);
+    //assert(status == MV_STATUS_OKAY);
     status = mvWriteChannel(log_handles.channel, (const uint8_t*)"\n", 1, &available);
-    assert(status == MV_STATUS_OKAY);
+    //assert(status == MV_STATUS_OKAY);
 }
 
 /**
@@ -216,6 +248,7 @@ int _write(int file, char *ptr, int length) {
     // will be invalid, ie. zero. If that's the case, open a channel
     if (log_handles.channel == 0) {
         OpenLogChannel();
+        while (log_handles.channel == 0) {}
     }
 
     // Write out the message string. Each time confirm that Microvisor

--- a/Demo/Src/main.c
+++ b/Demo/Src/main.c
@@ -61,6 +61,13 @@ const osThreadAttr_t DebugTask_attributes = {
     .stack_size = 1024
 };
 
+osThreadId_t NetworkTask;
+const osThreadAttr_t NetworkTask_attributes = {
+    .name = "NetworkTask",
+    .priority = (osPriority_t) osPriorityHigh,
+    .stack_size = 1024
+};
+
 /* USER CODE BEGIN PV */
 
 /* USER CODE END PV */
@@ -70,6 +77,7 @@ void SystemClock_Config(void);
 static void MX_GPIO_Init(void);
 void StartGPIOTask(void *argument);
 void StartDebugTask(void *argument);
+void StartNetworkTask(void *argument);
 
 /* USER CODE BEGIN PFP */
 
@@ -130,6 +138,7 @@ int main(void)
 
     /* Create the thread(s) */
     /* creation of defaultTask */
+    NetworkTask = osThreadNew(StartNetworkTask, NULL, &NetworkTask_attributes);
     GPIOTask = osThreadNew(StartGPIOTask, NULL, &GPIOTask_attributes);
     DebugTask = osThreadNew(StartDebugTask, NULL, &DebugTask_attributes);
 
@@ -199,11 +208,11 @@ static void MX_GPIO_Init(void)
 
 /* USER CODE BEGIN Header_StartGPIOTask */
 /**
-  * @brief  Function implementing the defaultTask thread.
+  * @brief  Function implementing the GPIOTask thread.
   * @param  argument: Not used
   * @retval None
   */
-/* USER CODE END Header_StartDefaultTask */
+/* USER CODE END Header_StartGPIOTask */
 void StartGPIOTask(void *argument)
 {
     /* USER CODE BEGIN 5 */
@@ -218,11 +227,11 @@ void StartGPIOTask(void *argument)
 
 /* USER CODE BEGIN Header_StartDebugTask */
 /**
-  * @brief  Function implementing the defaultTask thread.
+  * @brief  Function implementing the DebugTask thread.
   * @param  argument: Not used
   * @retval None
   */
-/* USER CODE END Header_StartDefaultTask */
+/* USER CODE END Header_StartDebugTask */
 void StartDebugTask(void *argument)
 {
     /* USER CODE BEGIN 5 */
@@ -233,8 +242,34 @@ void StartDebugTask(void *argument)
     for(;;)
     {
         printf("Ping %u\n", n);
+        printf("Logging alive\n");
         n++;
         osDelay(1000);
+    }
+    /* USER CODE END 5 */
+}
+
+/* USER CODE BEGIN Header_StartNetworkTask */
+/**
+  * @brief  Function implementing the NetworkTask thread.
+  * @param  argument: Not used
+  * @retval None
+  */
+/* USER CODE END Header_StartNetworkTask */
+void StartNetworkTask(void *argument)
+{
+    /* USER CODE BEGIN 5 */
+    OpenNetworkNotifications();
+    /* Infinite loop */
+    for(;;)
+    {
+        // Check whether notification ISR raised
+        if (NotificationIRQRaised()) {
+            // Call DSR if so
+            HandleIRQ();
+            ClearNotificationIRQ();
+        }
+        osDelay(10);
     }
     /* USER CODE END 5 */
 }


### PR DESCRIPTION
the server

Look for network connection notifications on a new thread, and arrange
for the logging channel to be closed when not connected to the server

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
